### PR TITLE
xid

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Transactional inbox/outbox message queuing.
 
-This Rails engine can be mounted in any PostgreSQL-backed Rails app.
+This Rails engine can be mounted in any Rails app backed by PostgreSQL 13 or higher.
 
 # Motivation
 The motivating use-case involves event-streaming with Kafka.

--- a/app/models/ohm/inbox/message.rb
+++ b/app/models/ohm/inbox/message.rb
@@ -21,7 +21,7 @@ module Ohm
       end
 
       def enqueue_job(processor_name = job_class.to_s)
-        perform_job_in(0.seconds, processor_name)
+        perform_job_in(2.seconds, processor_name)
       end
 
       def perform_job_in(interval, processor_name = job_class.to_s)

--- a/app/models/ohm/outbox/message.rb
+++ b/app/models/ohm/outbox/message.rb
@@ -30,7 +30,7 @@ module Ohm
       end
 
       def enqueue_job(processor_name = job_class.to_s)
-        perform_job_in(0.seconds, processor_name)
+        perform_job_in(2.seconds, processor_name)
       end
 
       def perform_job_in(interval, processor_name = job_class.to_s)

--- a/db/migrate/20240526021205_add_xid_to_ohm_messages.rb
+++ b/db/migrate/20240526021205_add_xid_to_ohm_messages.rb
@@ -1,0 +1,38 @@
+# typed: false
+
+class AddXidToOhmMessages < ActiveRecord::Migration[6.1]
+  def change
+    # TODO:
+    # - adjust indexes
+    # - verify whether this works in Rails 6.x
+    # - extract to a gem
+    #   - reference: https://github.com/alassek/activerecord-pg_enum
+    # - submit upstream
+    [
+      :ohm_inbox_messages,
+      :ohm_outbox_messages
+    ].each do |table|
+      add_column(
+        table,
+        :xid,
+        :xid8,
+        null: false,
+        default: -> { "pg_snapshot_xmin(pg_current_snapshot())" }
+      )
+      add_index table, :xid
+    end
+
+    [
+      :ohm_inbox_completions,
+      :ohm_outbox_completions
+    ].each do |table|
+      add_column(
+        table,
+        :last_completed_message_xid,
+        :xid8,
+        null: false
+      )
+      add_index table, :last_completed_message_xid
+    end
+  end
+end

--- a/lib/ohm/engine.rb
+++ b/lib/ohm/engine.rb
@@ -5,5 +5,9 @@ module Ohm
     isolate_namespace Ohm
     config.generators.api_only = true
     config.generators.test_framework = :rspec
+
+    initializer "ohm.enable_pg_xid8" do
+      require "pg_xid8"
+    end
   end
 end

--- a/lib/pg_xid8.rb
+++ b/lib/pg_xid8.rb
@@ -1,0 +1,90 @@
+# typed: false
+
+require "active_record"
+
+# PostgreSQL 13 introduced xid8, an unsigned 64-bit integer type. It is
+# used to provide each transaction with a sequential identifier.
+#
+# https://github.com/postgres/postgres/commit/aeec457de8a8820368e343e791accffe24dc7198
+# https://www.postgresql.org/docs/current/transaction-id.html
+#
+# A database that processed 1,000,000 transactions per second would take 584,542
+# years to exhaust this range.
+module PgXid8
+  module Type
+    class Xid8 < ::ActiveModel::Type::Integer
+      def type
+        :xid8
+      end
+
+      private
+
+      def max_value
+        # exclusive upper bound
+        0x10000000000000000 # 2**64
+      end
+
+      def min_value
+        0
+      end
+
+      def _limit
+        8 # bytes
+      end
+    end
+  end
+
+  module Column
+    # Create an xid8 column inside a table statement, e.g.
+    #
+    #   create_table :messages do |t|
+    #     t.xid8 :transaction_id
+    #   end
+    #
+    def xid8(name, **options)
+      column(name, :xid8, **options)
+    end
+  end
+
+  module InitializeTypeMap
+    def initialize_type_map(m)
+      super(m)
+      m.register_type("xid8", ::PgXid8::Type::Xid8.new)
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  require "active_record/connection_adapters/postgresql_adapter"
+
+  # Satisfy the typechecker, which is unaware of PostgreSQLAdapter.
+  unless defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+    module ActiveRecord::ConnectionAdapters
+      class PostgreSQLAdapter < AbstractAdapter
+        NATIVE_DATABASE_TYPES = {}
+      end
+    end
+  end
+
+  # This eliminates a warning in ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+  # https://github.com/rails/rails/blob/747a03ba7722b6f0a7ce42e86cea83cf07a2e6ef/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L834
+  #
+  #   unknown OID 5069: failed to recognize type of 'transaction_id'. It will be treated as String.
+  #
+  # https://discuss.rubyonrails.org/t/global-custom-database-type-registration/84623
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.singleton_class.prepend(PgXid8::InitializeTypeMap)
+
+  # This eliminates an error in ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper#table
+  # https://github.com/rails/rails/blob/747a03ba7722b6f0a7ce42e86cea83cf07a2e6ef/activerecord/lib/active_record/schema_dumper.rb#L180
+  #
+  #   Unknown type 'xid' for column 'transaction_id'
+  #
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:xid8] = {name: "xid8"}
+
+  ActiveRecord::ConnectionAdapters::TableDefinition.prepend(PgXid8::Column)
+  ActiveRecord::ConnectionAdapters::Table.prepend(PgXid8::Column)
+
+  # This doesn't appear to be necessary, unless you wanted to override a model's
+  # attribute that was not a Xid8 by default.
+  ActiveRecord::Type.register(:xid8, PgXid8::Type::Xid8, adapter: :postgresql)
+end

--- a/rbi/ohm.rbi
+++ b/rbi/ohm.rbi
@@ -261,3 +261,31 @@ module Ohm
     end
   end
 end
+
+module PgXid8
+  module Type
+    class Xid8 < ::ActiveModel::Type::Integer
+      sig { returns(Symbol) }
+      def type; end
+
+      sig { returns(Integer) }
+      def max_value; end
+
+      sig { returns(Integer) }
+      def min_value; end
+
+      sig { returns(Integer) }
+      def _limit; end
+    end
+  end
+
+  module Column
+    sig { params(name: T.any(String, Symbol), options: T.untyped).returns(T.self_type) }
+    def xid8(name, **options); end
+  end
+
+  module InitializeTypeMap
+    sig { params(m: T.untyped).returns(T.untyped) }
+    def initialize_type_map(m); end
+  end
+end

--- a/sorbet/rbi/dsl/dummy/inbox/bar_message.rbi
+++ b/sorbet/rbi/dsl/dummy/inbox/bar_message.rbi
@@ -774,6 +774,9 @@ class Dummy::Inbox::BarMessage
     sig { void }
     def restore_value!; end
 
+    sig { void }
+    def restore_xid!; end
+
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_created_at; end
 
@@ -821,6 +824,12 @@ class Dummy::Inbox::BarMessage
 
     sig { returns(T::Boolean) }
     def saved_change_to_value?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_xid?; end
 
     sig { returns(::String) }
     def type; end
@@ -980,6 +989,54 @@ class Dummy::Inbox::BarMessage
 
     sig { returns(T::Boolean) }
     def will_save_change_to_value?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_xid?; end
+
+    sig { returns(::Integer) }
+    def xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_was; end
+
+    sig { void }
+    def xid_will_change!; end
   end
 
   module GeneratedRelationMethods

--- a/sorbet/rbi/dsl/dummy/inbox/foo_message.rbi
+++ b/sorbet/rbi/dsl/dummy/inbox/foo_message.rbi
@@ -774,6 +774,9 @@ class Dummy::Inbox::FooMessage
     sig { void }
     def restore_value!; end
 
+    sig { void }
+    def restore_xid!; end
+
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_created_at; end
 
@@ -821,6 +824,12 @@ class Dummy::Inbox::FooMessage
 
     sig { returns(T::Boolean) }
     def saved_change_to_value?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_xid?; end
 
     sig { returns(::String) }
     def type; end
@@ -980,6 +989,54 @@ class Dummy::Inbox::FooMessage
 
     sig { returns(T::Boolean) }
     def will_save_change_to_value?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_xid?; end
+
+    sig { returns(::Integer) }
+    def xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_was; end
+
+    sig { void }
+    def xid_will_change!; end
   end
 
   module GeneratedRelationMethods

--- a/sorbet/rbi/dsl/dummy/outbox/bar_message.rbi
+++ b/sorbet/rbi/dsl/dummy/outbox/bar_message.rbi
@@ -774,6 +774,9 @@ class Dummy::Outbox::BarMessage
     sig { void }
     def restore_value!; end
 
+    sig { void }
+    def restore_xid!; end
+
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_created_at; end
 
@@ -821,6 +824,12 @@ class Dummy::Outbox::BarMessage
 
     sig { returns(T::Boolean) }
     def saved_change_to_value?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_xid?; end
 
     sig { returns(::String) }
     def type; end
@@ -980,6 +989,54 @@ class Dummy::Outbox::BarMessage
 
     sig { returns(T::Boolean) }
     def will_save_change_to_value?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_xid?; end
+
+    sig { returns(::Integer) }
+    def xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_was; end
+
+    sig { void }
+    def xid_will_change!; end
   end
 
   module GeneratedRelationMethods

--- a/sorbet/rbi/dsl/dummy/outbox/foo_message.rbi
+++ b/sorbet/rbi/dsl/dummy/outbox/foo_message.rbi
@@ -774,6 +774,9 @@ class Dummy::Outbox::FooMessage
     sig { void }
     def restore_value!; end
 
+    sig { void }
+    def restore_xid!; end
+
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_created_at; end
 
@@ -821,6 +824,12 @@ class Dummy::Outbox::FooMessage
 
     sig { returns(T::Boolean) }
     def saved_change_to_value?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_xid?; end
 
     sig { returns(::String) }
     def type; end
@@ -980,6 +989,54 @@ class Dummy::Outbox::FooMessage
 
     sig { returns(T::Boolean) }
     def will_save_change_to_value?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_xid?; end
+
+    sig { returns(::Integer) }
+    def xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_was; end
+
+    sig { void }
+    def xid_will_change!; end
   end
 
   module GeneratedRelationMethods

--- a/sorbet/rbi/dsl/ohm/inbox/completion.rbi
+++ b/sorbet/rbi/dsl/ohm/inbox/completion.rbi
@@ -700,6 +700,51 @@ class Ohm::Inbox::Completion
     sig { void }
     def last_completed_message_id_will_change!; end
 
+    sig { returns(::Integer) }
+    def last_completed_message_xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def last_completed_message_xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def last_completed_message_xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def last_completed_message_xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def last_completed_message_xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def last_completed_message_xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def last_completed_message_xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def last_completed_message_xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def last_completed_message_xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def last_completed_message_xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_was; end
+
+    sig { void }
+    def last_completed_message_xid_will_change!; end
+
     sig { returns(T.untyped) }
     def message_key; end
 
@@ -848,6 +893,9 @@ class Ohm::Inbox::Completion
     def restore_last_completed_message_id!; end
 
     sig { void }
+    def restore_last_completed_message_xid!; end
+
+    sig { void }
     def restore_message_key!; end
 
     sig { void }
@@ -882,6 +930,12 @@ class Ohm::Inbox::Completion
 
     sig { returns(T::Boolean) }
     def saved_change_to_last_completed_message_id?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_last_completed_message_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_last_completed_message_xid?; end
 
     sig { returns(T.nilable([T.untyped, T.untyped])) }
     def saved_change_to_message_key; end
@@ -963,6 +1017,9 @@ class Ohm::Inbox::Completion
 
     sig { returns(T::Boolean) }
     def will_save_change_to_last_completed_message_id?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_last_completed_message_xid?; end
 
     sig { returns(T::Boolean) }
     def will_save_change_to_message_key?; end

--- a/sorbet/rbi/dsl/ohm/inbox/message.rbi
+++ b/sorbet/rbi/dsl/ohm/inbox/message.rbi
@@ -769,6 +769,9 @@ class Ohm::Inbox::Message
     sig { void }
     def restore_value!; end
 
+    sig { void }
+    def restore_xid!; end
+
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_created_at; end
 
@@ -816,6 +819,12 @@ class Ohm::Inbox::Message
 
     sig { returns(T::Boolean) }
     def saved_change_to_value?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_xid?; end
 
     sig { returns(::String) }
     def type; end
@@ -975,6 +984,54 @@ class Ohm::Inbox::Message
 
     sig { returns(T::Boolean) }
     def will_save_change_to_value?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_xid?; end
+
+    sig { returns(::Integer) }
+    def xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_was; end
+
+    sig { void }
+    def xid_will_change!; end
   end
 
   module GeneratedRelationMethods

--- a/sorbet/rbi/dsl/ohm/outbox/completion.rbi
+++ b/sorbet/rbi/dsl/ohm/outbox/completion.rbi
@@ -705,6 +705,51 @@ class Ohm::Outbox::Completion
     sig { void }
     def last_completed_message_id_will_change!; end
 
+    sig { returns(::Integer) }
+    def last_completed_message_xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def last_completed_message_xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def last_completed_message_xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def last_completed_message_xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def last_completed_message_xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def last_completed_message_xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def last_completed_message_xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def last_completed_message_xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def last_completed_message_xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def last_completed_message_xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def last_completed_message_xid_was; end
+
+    sig { void }
+    def last_completed_message_xid_will_change!; end
+
     sig { returns(T.untyped) }
     def message_key; end
 
@@ -853,6 +898,9 @@ class Ohm::Outbox::Completion
     def restore_last_completed_message_id!; end
 
     sig { void }
+    def restore_last_completed_message_xid!; end
+
+    sig { void }
     def restore_message_key!; end
 
     sig { void }
@@ -887,6 +935,12 @@ class Ohm::Outbox::Completion
 
     sig { returns(T::Boolean) }
     def saved_change_to_last_completed_message_id?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_last_completed_message_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_last_completed_message_xid?; end
 
     sig { returns(T.nilable([T.untyped, T.untyped])) }
     def saved_change_to_message_key; end
@@ -968,6 +1022,9 @@ class Ohm::Outbox::Completion
 
     sig { returns(T::Boolean) }
     def will_save_change_to_last_completed_message_id?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_last_completed_message_xid?; end
 
     sig { returns(T::Boolean) }
     def will_save_change_to_message_key?; end

--- a/sorbet/rbi/dsl/ohm/outbox/message.rbi
+++ b/sorbet/rbi/dsl/ohm/outbox/message.rbi
@@ -769,6 +769,9 @@ class Ohm::Outbox::Message
     sig { void }
     def restore_value!; end
 
+    sig { void }
+    def restore_xid!; end
+
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_created_at; end
 
@@ -816,6 +819,12 @@ class Ohm::Outbox::Message
 
     sig { returns(T::Boolean) }
     def saved_change_to_value?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_xid; end
+
+    sig { returns(T::Boolean) }
+    def saved_change_to_xid?; end
 
     sig { returns(::String) }
     def type; end
@@ -975,6 +984,54 @@ class Ohm::Outbox::Message
 
     sig { returns(T::Boolean) }
     def will_save_change_to_value?; end
+
+    sig { returns(T::Boolean) }
+    def will_save_change_to_xid?; end
+
+    sig { returns(::Integer) }
+    def xid; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def xid=(value); end
+
+    sig { returns(T::Boolean) }
+    def xid?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def xid_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def xid_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_change_to_be_saved; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def xid_previous_change; end
+
+    sig { params(from: ::Integer, to: ::Integer).returns(T::Boolean) }
+    def xid_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def xid_was; end
+
+    sig { void }
+    def xid_will_change!; end
   end
 
   module GeneratedRelationMethods

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_20_190801) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_26_021205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "plpgsql"
@@ -22,7 +22,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_190801) do
     t.bigint "last_completed_message_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.xid8 "last_completed_message_xid", null: false
     t.index ["last_completed_message_id"], name: "index_ohm_inbox_completions_on_last_completed_message_id"
+    t.index ["last_completed_message_xid"], name: "index_ohm_inbox_completions_on_last_completed_message_xid"
     t.index ["processor_name", "message_type", "message_key", "last_completed_message_id"], name: "index_ohm_inbox_completions_on_processor_message_completed"
     t.index ["processor_name", "message_type", "message_key"], name: "index_ohm_inbox_completions_on_processor_message_type_key_uniq", unique: true
   end
@@ -34,8 +36,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_190801) do
     t.jsonb "metadata", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.xid8 "xid", default: -> { "pg_snapshot_xmin(pg_current_snapshot())" }, null: false
     t.index ["created_at"], name: "index_ohm_inbox_messages_on_created_at"
     t.index ["type", "key"], name: "index_ohm_inbox_messages_on_type_and_key"
+    t.index ["xid"], name: "index_ohm_inbox_messages_on_xid"
   end
 
   create_table "ohm_outbox_completions", force: :cascade do |t|
@@ -45,7 +49,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_190801) do
     t.bigint "last_completed_message_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.xid8 "last_completed_message_xid", null: false
     t.index ["last_completed_message_id"], name: "index_ohm_outbox_completions_on_last_completed_message_id"
+    t.index ["last_completed_message_xid"], name: "index_ohm_outbox_completions_on_last_completed_message_xid"
     t.index ["processor_name", "message_type", "message_key", "last_completed_message_id"], name: "index_ohm_outbox_completions_on_processor_message_completed"
     t.index ["processor_name", "message_type", "message_key"], name: "index_ohm_outbox_completions_on_processor_message_type_key_uniq", unique: true
   end
@@ -57,8 +63,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_190801) do
     t.jsonb "metadata", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.xid8 "xid", default: -> { "pg_snapshot_xmin(pg_current_snapshot())" }, null: false
     t.index ["created_at"], name: "index_ohm_outbox_messages_on_created_at"
     t.index ["type", "key"], name: "index_ohm_outbox_messages_on_type_and_key"
+    t.index ["xid"], name: "index_ohm_outbox_messages_on_xid"
   end
 
   add_foreign_key "ohm_inbox_completions", "ohm_inbox_messages", column: "last_completed_message_id"

--- a/spec/support/shared_examples/transactional_message_examples.rb
+++ b/spec/support/shared_examples/transactional_message_examples.rb
@@ -13,6 +13,12 @@ RSpec.shared_examples :transactional_message do
   let(:job_class) { message.job_class }
   let(:processor_name) { job_class.name }
 
+  def create_from(message, attrs = {})
+    message.class.create!(
+      message.attributes.except("xid", "id").merge(attrs)
+    )
+  end
+
   describe "#valid?" do
     it "is true with valid attributes" do
       expect(message).to be_valid
@@ -34,14 +40,14 @@ RSpec.shared_examples :transactional_message do
     end
 
     it "is true for messages before the last processed message" do
-      message2 = message.dup.tap(&:save!)
+      message2 = message.class.create!(message.attributes.except("xid", "id"))
       message.processed(processor_name:)
       message2.processed(processor_name:)
       expect(message.processed?(processor_name:)).to eq(true)
     end
 
     it "is false for messages after the last processed message" do
-      message2 = message.dup.tap(&:save!)
+      message2 = message.class.create!(message.attributes.except("xid", "id"))
       message.processed(processor_name:)
       expect(message2.processed?(processor_name:)).to eq(false)
     end
@@ -62,7 +68,9 @@ RSpec.shared_examples :transactional_message do
     end
 
     it "ignores other message keys" do
-      message_x = message.dup.tap { |m| m.update!(key: SecureRandom.uuid) }
+      message_x = message.class.create!(
+        message.attributes.except("xid", "id").merge("key" => SecureRandom.uuid)
+      )
       message_x.processed(processor_name:)
       expect(message.processed?(processor_name:)).to eq(false)
     end
@@ -93,7 +101,7 @@ RSpec.shared_examples :transactional_message do
     end
 
     it "updates completion if recorded from an earlier message" do
-      message2 = message.dup.tap(&:save!)
+      message2 = message.class.create!(message.attributes.except("xid", "id"))
       message.processed(processor_name:)
       c = completions.last
 
@@ -106,7 +114,9 @@ RSpec.shared_examples :transactional_message do
 
     it "handles complex keys" do
       message.update!(key: {a: 1, b: 2})
-      message2 = message.dup.tap { |m| m.update!(key: {b: 2, a: 1}) }
+      message2 = message.class.create!(
+        message.attributes.except("xid", "id").merge("key" => {b: 2, a: 1})
+      )
       message.processed(processor_name:)
       c = completions.last
 
@@ -121,8 +131,14 @@ RSpec.shared_examples :transactional_message do
   describe "#unprocessed_predecessors" do
     before(:each) { message.save! }
 
-    it "includes unprocessed messages with same type and key, but smaller id" do
-      message2 = message.dup.tap(&:save!)
+    it "includes unprocessed messages with same type and key, but smaller xid" do
+      message2 = message.class.create!(message.attributes.except("xid", "id"))
+      expect(message2.unprocessed_predecessors(processor_name:))
+        .to contain_exactly(message)
+    end
+
+    it "includes unprocessed messages with same type, key and xid, but smaller id" do
+      message2 = message.class.create!(message.attributes.except("id"))
       expect(message2.unprocessed_predecessors(processor_name:))
         .to contain_exactly(message)
     end
@@ -134,19 +150,27 @@ RSpec.shared_examples :transactional_message do
     end
 
     it "excludes unprocessed messages with different key" do
-      message2 = message.dup.tap { |m| m.update!(key: SecureRandom.uuid) }
+      message2 = message.class.create!(
+        message.attributes.except("xid", "id").merge("key" => SecureRandom.uuid)
+      )
       expect(message2.unprocessed_predecessors(processor_name:))
         .to be_empty
     end
 
-    it "excludes unprocessed messages with same or greater id" do
-      message.dup.tap(&:save!)
+    it "excludes unprocessed messages with same xid but greater id" do
+      message.class.create!(message.attributes.except("id"))
+      expect(message.unprocessed_predecessors(processor_name:))
+        .to be_empty
+    end
+
+    it "excludes unprocessed messages with greater xid" do
+      message.class.create!(message.attributes.except("xid", "id"))
       expect(message.unprocessed_predecessors(processor_name:))
         .to be_empty
     end
 
     it "excludes processed messages" do
-      message2 = message.dup.tap(&:save!)
+      message2 = message.class.create!(message.attributes.except("xid", "id"))
       message.processed(processor_name:)
 
       expect(message2.unprocessed_predecessors(processor_name:))
@@ -157,7 +181,9 @@ RSpec.shared_examples :transactional_message do
 
     it "handles complex keys" do
       message.update!(key: {a: 1, b: 2})
-      message2 = message.dup.tap { |m| m.update!(key: {b: 2, a: 1}) }
+      message2 = message.class.create!(
+        message.attributes.except("xid", "id").merge("key" => {b: 2, a: 1})
+      )
       expect(message2.unprocessed_predecessors(processor_name:))
         .to contain_exactly(message)
     end
@@ -220,7 +246,9 @@ RSpec.shared_examples :transactional_message do
   describe ".next_in_line" do
     before(:each) { message.save! }
 
-    let!(:message2) { message.dup.tap(&:save!) }
+    let!(:message2) do
+      message.class.create!(message.attributes.except("xid", "id"))
+    end
     let(:key) { message.key }
 
     it "returns the next unprocessed message" do
@@ -272,6 +300,365 @@ RSpec.shared_examples :transactional_message do
         message.processed(processor_name: name2)
         expect(message.class.next_in_line(key:, processor_name: [name1, name2]))
           .to eq(message2)
+      end
+    end
+
+    context "with concurrent transactions" do
+      # Messages have an auto-incrementing id sequence whose values are consumed
+      # on each insert statement. The sequence increment is immediately visible
+      # to all other transactions, but the message itself is not visible until
+      # we commit the transaction.
+      #
+      # We can't assume messages will be committed in the same order as their
+      # id sequence. With concurrent db connections, a newly-committed message
+      # could appear while another new message with a lower id is still in an
+      # uncommitted state.
+      #
+      # We need to ensure that .next_in_line doesn't accidentally skip messages
+      # in these scenarios.
+
+      before(:each) do
+        [message, message2].each { |m| m.processed(processor_name:) }
+      end
+
+      def new_message(attributes)
+        message.class.new(
+          message.attributes.except("xid", "id").merge(attributes)
+        )
+      end
+
+      it "avoids skipping uncommitted messages (scenario 1)" do
+        # CLIENT A| BEGIN..INSERT...............COMMIT
+        # CLIENT B|    BEGIN..INSERT..COMMIT
+        # CLIENT C|                        SELECT    SELECT
+        client_a = Thread.new do
+          ApplicationRecord.transaction do
+            @a_begun = true
+            new_message(metadata: {"client" => "a"}).save!
+            @a_inserted = true
+            sleep 0.01 until @selected1
+          end
+          @a_committed = true
+        end
+        client_b = Thread.new do
+          sleep 0.01 until @a_begun
+          ApplicationRecord.transaction do
+            sleep 0.01 until @a_inserted
+            new_message(metadata: {"client" => "b"}).save!
+          end
+          @b_committed = true
+        end
+        client_c = Thread.new do
+          sleep 0.01 until @b_committed
+          @unprocessed1 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line1 = message.class.next_in_line(key:, processor_name:)
+          @selected1 = true
+          sleep 0.01 until @a_committed
+          @unprocessed2 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line2 = message.class.next_in_line(key:, processor_name:)
+        end
+        [client_a, client_b, client_c].each(&:join)
+
+        expect(@unprocessed1.map { |m| m.metadata["client"] }).to eq(["b"])
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed2.map { |m| m.metadata["client"] }).to eq(["a", "b"])
+        expect(@next_in_line2.metadata["client"]).to eq("a")
+      end
+
+      it "avoids skipping uncommitted messages (scenario 2)" do
+        # CLIENT A| BEGIN...INSERT..................COMMIT
+        # CLIENT B|    BEGIN...INSERT.........................COMMIT
+        # CLIENT C|       BEGIN...INSERT..COMMIT
+        # CLIENT D|                            SELECT    SELECT    SELECT
+        client_a = Thread.new do
+          ApplicationRecord.transaction do
+            @a_begun = true
+            new_message(metadata: {"client" => "a"}).save!
+            @a_inserted = true
+            sleep 0.01 until @selected1
+          end
+          @a_committed = true
+        end
+        client_b = Thread.new do
+          sleep 0.01 until @a_begun
+          ApplicationRecord.transaction do
+            @b_begun = true
+            sleep 0.01 until @a_inserted
+            new_message(metadata: {"client" => "b"}).save!
+            @b_inserted = true
+            sleep 0.01 until @selected2
+          end
+          @b_committed = true
+        end
+        client_c = Thread.new do
+          sleep 0.01 until @b_begun
+          ApplicationRecord.transaction do
+            sleep 0.01 until @b_inserted
+            new_message(metadata: {"client" => "c"}).save!
+          end
+          @c_committed = true
+        end
+        client_d = Thread.new do
+          sleep 0.01 until @c_committed
+          @unprocessed1 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line1 = message.class.next_in_line(key:, processor_name:)
+          @selected1 = true
+          sleep 0.01 until @a_committed
+          @unprocessed2 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line2 = message.class.next_in_line(key:, processor_name:)
+          @selected2 = true
+          sleep 0.01 until @b_committed
+          @unprocessed3 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line3 = message.class.next_in_line(key:, processor_name:)
+        end
+        [client_a, client_b, client_c, client_d].each(&:join)
+
+        expect(@unprocessed1.map { |m| m.metadata["client"] }).to eq(["c"])
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed2.map { |m| m.metadata["client"] }).to eq(["a", "c"])
+        expect(@next_in_line2.metadata["client"]).to eq("a")
+
+        expect(@unprocessed3.map { |m| m.metadata["client"] }).to eq(["a", "b", "c"])
+        expect(@next_in_line3.metadata["client"]).to eq("a")
+      end
+
+      it "avoids skipping uncommitted messages (scenario 3)" do
+        # CLIENT A| BEGIN..........INSERT...COMMIT
+        # CLIENT B|    BEGIN...INSERT.................COMMIT
+        # CLIENT C|       BEGIN........INSERT...................COMMIT
+        # CLIENT D|                              SELECT    SELECT    SELECT
+        client_a = Thread.new do
+          ApplicationRecord.transaction do
+            @a_begun = true
+            sleep 0.01 until @b_inserted
+            new_message(metadata: {"client" => "a"}).save!
+            @a_inserted = true
+            sleep 0.01 until @c_inserted
+          end
+          @a_committed = true
+        end
+        client_b = Thread.new do
+          sleep 0.01 until @a_begun
+          ApplicationRecord.transaction do
+            @b_begun = true
+            sleep 0.01 until @c_begun
+            new_message(metadata: {"client" => "b"}).save!
+            @b_inserted = true
+            sleep 0.01 until @selected1
+          end
+          @b_committed = true
+        end
+        client_c = Thread.new do
+          sleep 0.01 until @b_begun
+          ApplicationRecord.transaction do
+            @c_begun = true
+            sleep 0.01 until @a_inserted
+            new_message(metadata: {"client" => "c"}).save!
+            @c_inserted = true
+            sleep 0.01 until @selected2
+          end
+          @c_committed = true
+        end
+        client_d = Thread.new do
+          sleep 0.01 until @a_committed
+          @unprocessed1 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line1 = message.class.next_in_line(key:, processor_name:)
+          @selected1 = true
+          sleep 0.01 until @b_committed
+          @unprocessed2 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line2 = message.class.next_in_line(key:, processor_name:)
+          @selected2 = true
+          sleep 0.01 until @c_committed
+          @unprocessed3 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line3 = message.class.next_in_line(key:, processor_name:)
+        end
+        [client_a, client_b, client_c, client_d].each(&:join)
+
+        expect(@unprocessed1.map { |m| m.metadata["client"] }).to eq(["a"])
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed2.map { |m| m.metadata["client"] }).to eq(["b", "a"])
+        expect(@next_in_line3.metadata["client"]).to eq("b")
+
+        expect(@unprocessed3.map { |m| m.metadata["client"] }).to eq(["b", "a", "c"])
+        expect(@next_in_line3.metadata["client"]).to eq("b")
+      end
+
+      it "avoids skipping uncommitted messages (scenario 4)" do
+        # CLIENT A| BEGIN...INSERT..................COMMIT
+        # CLIENT B|    BEGIN...INSERT..........................................COMMIT
+        # CLIENT C|       BEGIN...INSERT..COMMIT
+        # CLIENT D|                            SELECT    SELECT  PROCESS  SELECT    SELECT
+        client_a = Thread.new do
+          ApplicationRecord.transaction do
+            @a_begun = true
+            new_message(metadata: {"client" => "a"}).save!
+            @a_inserted = true
+            sleep 0.01 until @selected1
+          end
+          @a_committed = true
+        end
+        client_b = Thread.new do
+          sleep 0.01 until @a_begun
+          ApplicationRecord.transaction do
+            @b_begun = true
+            sleep 0.01 until @a_inserted
+            new_message(metadata: {"client" => "b"}).save!
+            @b_inserted = true
+            sleep 0.01 until @selected3
+          end
+          @b_committed = true
+        end
+        client_c = Thread.new do
+          sleep 0.01 until @b_begun
+          ApplicationRecord.transaction do
+            sleep 0.01 until @b_inserted
+            new_message(metadata: {"client" => "c"}).save!
+          end
+          @c_committed = true
+        end
+        client_d = Thread.new do
+          sleep 0.01 until @c_committed
+          @unprocessed1 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line1 = message.class.next_in_line(key:, processor_name:)
+          @selected1 = true
+          sleep 0.01 until @a_committed
+          @unprocessed2 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line2 = message.class.next_in_line(key:, processor_name:)
+          @selected2 = true
+          @next_in_line2.processed(processor_name:)
+          @unprocessed3 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line3 = message.class.next_in_line(key:, processor_name:)
+          @selected3 = true
+          sleep 0.01 until @b_committed
+          @unprocessed4 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line4 = message.class.next_in_line(key:, processor_name:)
+        end
+        [client_a, client_b, client_c, client_d].each(&:join)
+
+        expect(@unprocessed1.map { |m| m.metadata["client"] }).to eq(["c"])
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed2.map { |m| m.metadata["client"] }).to eq(["a", "c"])
+        expect(@next_in_line2.metadata["client"]).to eq("a")
+
+        expect(@unprocessed3.map { |m| m.metadata["client"] }).to eq(["c"])
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed4.map { |m| m.metadata["client"] }).to eq(["b", "c"])
+        expect(@next_in_line4.metadata["client"]).to eq("b")
+      end
+
+      it "avoids skipping uncommitted messages (scenario 5)" do
+        # TODO: set up scenario with multiple inserts in a single transaction
+        # CLIENT A| BEGIN...INSERT..................COMMIT
+        # CLIENT B|    BEGIN...INSERT..........................................COMMIT
+        # CLIENT C|       BEGIN...INSERT..COMMIT
+        # CLIENT D|                            SELECT    SELECT  PROCESS  SELECT    SELECT
+        client_a = Thread.new do
+          ApplicationRecord.transaction do
+            @a_begun = true
+            new_message(metadata: {"client" => "a"}).save!
+            @a_inserted = true
+            sleep 0.01 until @selected1
+          end
+          @a_committed = true
+        end
+        client_b = Thread.new do
+          sleep 0.01 until @a_begun
+          ApplicationRecord.transaction do
+            @b_begun = true
+            sleep 0.01 until @a_inserted
+            new_message(metadata: {"client" => "b"}).save!
+            @b_inserted = true
+            sleep 0.01 until @selected3
+          end
+          @b_committed = true
+        end
+        client_c = Thread.new do
+          sleep 0.01 until @b_begun
+          ApplicationRecord.transaction do
+            sleep 0.01 until @b_inserted
+            new_message(metadata: {"client" => "c"}).save!
+          end
+          @c_committed = true
+        end
+        client_d = Thread.new do
+          sleep 0.01 until @c_committed
+          @unprocessed1 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line1 = message.class.next_in_line(key:, processor_name:)
+          @selected1 = true
+          sleep 0.01 until @a_committed
+          @unprocessed2 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line2 = message.class.next_in_line(key:, processor_name:)
+          @selected2 = true
+          @next_in_line2.processed(processor_name:)
+          @unprocessed3 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line3 = message.class.next_in_line(key:, processor_name:)
+          @selected3 = true
+          sleep 0.01 until @b_committed
+          @unprocessed4 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line4 = message.class.next_in_line(key:, processor_name:)
+        end
+        [client_a, client_b, client_c, client_d].each(&:join)
+
+        expect(@unprocessed1.map { |m| m.metadata["client"] }).to eq(["c"])
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed2.map { |m| m.metadata["client"] }).to eq(["a", "c"])
+        expect(@next_in_line2.metadata["client"]).to eq("a")
+
+        expect(@unprocessed3.map { |m| m.metadata["client"] }).to eq(["c"])
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed4.map { |m| m.metadata["client"] }).to eq(["b", "c"])
+        expect(@next_in_line4.metadata["client"]).to eq("b")
+      end
+
+      it "skips rolled-back messages" do
+        # CLIENT A| BEGIN........INSERT..ROLLBACK
+        # CLIENT B|    BEGIN....................INSERT..COMMIT
+        # CLIENT C|         SELECT              SELECT       SELECT
+        client_a = Thread.new do
+          ApplicationRecord.transaction do
+            sleep 0.01 until @selected1
+            new_message(metadata: {"client" => "a"}, xid: -1).save(validate: false)
+          rescue ActiveModel::RangeError
+            @a_rolledback = true
+          end
+        end
+        client_b = Thread.new do
+          ApplicationRecord.transaction do
+            sleep 0.01 until @a_rolledback
+            new_message(metadata: {"client" => "b"}).save!
+            sleep 0.01 until @selected2
+          end
+          @b_committed = true
+        end
+        client_c = Thread.new do
+          @unprocessed1 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line1 = message.class.next_in_line(key:, processor_name:)
+          @selected1 = true
+          sleep 0.01 until @a_rolledback
+          @unprocessed2 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line2 = message.class.next_in_line(key:, processor_name:)
+          @selected2 = true
+          sleep 0.01 until @b_committed
+          @unprocessed3 = message.class.unprocessed(processor_name:).order(:id).to_a
+          @next_in_line3 = message.class.next_in_line(key:, processor_name:)
+        end
+        [client_a, client_b, client_c].each(&:join)
+
+        expect(@unprocessed1).to be_empty
+        expect(@next_in_line1).to eq(nil)
+
+        expect(@unprocessed2).to be_empty
+        expect(@next_in_line2).to eq(nil)
+
+        expect(@unprocessed3.map { |m| m.metadata["client"] }).to eq(["b"])
+        expect(@next_in_line3.metadata["client"]).to eq("b")
       end
     end
   end


### PR DESCRIPTION
Draft an interesting solution to the message ordering race-condition that can arise during concurrent inserts.

https://event-driven.io/en/ordering_in_postgres_outbox/
___
This is an innovative solution, but it has a few drawbacks.

First, it adds complexity, though not all that much. Second, it's only supported on PostgreSQL 13 and newer. Finally, it can introduce noticeable message-processing delays if run in an app that has any long-running transactions, regardless of whether those transactions involve messages.

Ultimately, the message-processing delay was the deal-breaker, because we can't anticipate what kind of transaction activity will be running in the downstream app that choses to use our engine. It could easily have long-running transactions that have nothing to do with the inbox/outbox, and these would end up delaying message-processing unnecessarily.

___

I wanted to capture this in a draft because in addition to the solution itself, implementing it involved some interesting steps along the way, such as extending ActiveRecord's PostgreSLQ support and simulating the race-condition in tests.