### PR TITLE
set up CI to use official odeko ruby docker image

### DIFF
--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -38,8 +38,8 @@ resources:
 - name: concourse-image-ruby
   type: registry-image
   source:
-    repository: docker.odeko.com/odeko/concourse-rails-base
-    tag: 3.1.2-slim
+    repository: docker.odeko.com/odeko/ruby-dev
+    tag: 3.1-slim
 - name: slack-alert
   type: slack-notification
   source:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -28,8 +28,8 @@ resources:
 - name: concourse-image-ruby
   type: registry-image
   source:
-    repository: docker.odeko.com/odeko/concourse-rails-base
-    tag: 3.1.2-slim
+    repository: docker.odeko.com/odeko/ruby-dev
+    tag: 3.1-slim
 - name: slack-alert
   type: slack-notification
   source:


### PR DESCRIPTION
Use official [Odeko Ruby Docker image](https://github.com/OdekoTeam/docker-ruby) which:
- standardizes on Debian Stable
- is regularly updated with security patches
- automatically applies Ruby patch versions
- should simplify image upgrades via a consistent and easy to maintain git repo

TODO:
- [x] update `pr` CI pipeline
- [x] update `main` CI pipeline