### PR TITLE
CI: gem publish open source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coil (1.3.0)
+    coil (1.3.1)
       pg
       rails (>= 6.0.6)
       sidekiq (>= 5.2)

--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -157,7 +157,7 @@ jobs:
   - in_parallel:
     - get: repo
       passed:
-      - gem-publish
+      - gem-publish-open-source
       trigger: true
       attempts: 3
     - get: concourse

--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -131,6 +131,26 @@ jobs:
       GEMINABOX_PRIVATE_URL: ((geminabox-url))
     attempts: 3
   on_failure: *simple_failure
+- name: gem-publish-open-source
+  serial: true
+  plan:
+  - in_parallel:
+    - get: repo
+      passed:
+      - gem-publish
+      trigger: true
+      params:
+        submodules: all
+        submodule_recursive: true
+      attempts: 3
+    - get: concourse
+      attempts: 3
+  - task: gem-publish-open-source
+    file: concourse/tasks/rails/publish-open-source/default.yml
+    params:
+      RUBYGEMS_API_KEY: ((rubygems-api-key))
+    attempts: 3
+  on_failure: *simple_failure
 - name: release
   serial: true
   plan:

--- a/lib/coil/version.rb
+++ b/lib/coil/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Coil
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
Add a CI job that publishes to rubygems.org
___
- [ ] run `fly` to update pipeline:
```sh
fly -t odeko set-pipeline -p coil-main -c ci/pipelines/main.yml
```