### PR TITLE
Update documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coil (1.3.2)
+    coil (1.3.3)
       pg (>= 0, < 2.0)
       rails (>= 6.0.6, < 8.0)
       sidekiq (>= 5.2, < 8.0)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coil [![concourse.odeko.com](https://concourse.odeko.com/api/v1/teams/main/pipelines/coil-main/jobs/test/badge)](https://concourse.odeko.com/teams/main/pipelines/coil-main)
 
-<img src="./solenoid.svg" width="35%">
+<img src="https://raw.githubusercontent.com/OdekoTeam/coil/main/solenoid.svg" width="35%">
 
 Transactional inbox/outbox message queuing.
 
@@ -30,8 +30,8 @@ as a synchronization mechanism.
 Add to the application's Gemfile:
 
 ```ruby
-gem "coil", source: "https://gem.odeko.com/"
-gem "schema_version_cache", source: "https://gem.odeko.com/"
+gem "coil"
+gem "schema_version_cache"
 ```
 
 Install engine and migrations:
@@ -53,7 +53,7 @@ Sidekiq.configure_server do |config|
 end
 ```
 
-Filter retryable errors out of airbrake:
+Filter retryable errors out of alerting, e.g. airbrake:
 ```ruby
 # config/initializers/airbrake.rb
 Airbrake.add_filter do |notice|

--- a/lib/coil/version.rb
+++ b/lib/coil/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Coil
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
A few small updates to the README.
___
Update installation instructions to use publicly available gem instead of Odeko's private gem server.

Use more generic error alerting language rather than Airbrake-specific language.

Use an absolute URL for image source, so the image will display correctly on RubyGems generated documentation. Below screenshot shows the broken image:

<img src="https://github.com/user-attachments/assets/cf9f4a0e-af9a-4c1d-9ce2-852950e7c5ab" width="75%" />