### PR TITLE
Tests: remove redundant local variable

### DIFF
--- a/spec/support/shared_examples/enqueue_messages_job_examples.rb
+++ b/spec/support/shared_examples/enqueue_messages_job_examples.rb
@@ -15,7 +15,6 @@ RSpec.shared_examples :enqueue_messages_job do
         .to change(job_class.jobs, :count)
         .by(1)
 
-      job_class = message.job_class
       job = job_class.jobs.last
 
       expect(job["args"]).to eq([message.key, job_class.name])


### PR DESCRIPTION
Remove a local variable that shadowed an existing variable of the same name with the same value.