### PR TITLE
Configuration: `sidekiq_queue`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coil (1.3.3)
+    coil (1.4.0)
       pg (>= 0, < 2.0)
       rails (>= 6.0.6, < 8.0)
       sidekiq (>= 5.2, < 8.0)

--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ rescue Coil::QueueLocking::LockWaitTimeout
 end
 ```
 
+## Configuration
+
+To adjust the configurable settings used within your application, create an
+initializer at `config/initializers/coil.rb` with the following content, then
+uncomment and adjust the settings you wish to change:
+```ruby
+# Coil.sidekiq_queue = "default"
+```
+
 ## Development
 
 Install development dependencies:

--- a/app/jobs/coil/application_job.rb
+++ b/app/jobs/coil/application_job.rb
@@ -3,5 +3,7 @@
 module Coil
   class ApplicationJob
     include Sidekiq::Worker
+
+    sidekiq_options queue: Coil.sidekiq_queue
   end
 end

--- a/lib/coil.rb
+++ b/lib/coil.rb
@@ -6,4 +6,5 @@ require "coil/engine"
 require "coil/queue_locking"
 
 module Coil
+  mattr_accessor :sidekiq_queue, default: "default"
 end

--- a/lib/coil/version.rb
+++ b/lib/coil/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Coil
-  VERSION = "1.3.3"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
Provide a `sidekiq_queue` configuration setting so the host application can easily control which Sidekiq queue Coil uses.

### Context
Without this setting, the host application would need to override the queue option in every job class, e.g.
```ruby
class Inbox::FooMessagesJob < Coil::TransactionalMessagesJob
  sidekiq_options queue: "example"
  # ...
end

class Inbox::BarMessagesJob < Coil::TransactionalMessagesJob
  sidekiq_options queue: "example"
  # ...
end

class Inbox::MessagesPeriodicJob < Coil::Inbox::MessagesPeriodicJob
  sidekiq_options queue: "example"
  # ...
end
```

With this setting, the host application can instead use an initializer to set the queue option that all Coil jobs will use:
```ruby
# config/initializers/coil.rb
Coil.sidekiq_queue = "example"
```