### PR TITLE
Fix: avoid error on orphaned messages

### DIFF
--- a/rbi/coil.rbi
+++ b/rbi/coil.rbi
@@ -378,6 +378,9 @@ class Coil::TransactionalMessagesPeriodicJob < ::Coil::ApplicationJob
 
   private
 
+  sig { params(type: String).returns(T.nilable(::Coil::AnyMessageClass)) }
+  def message_class_for(type); end
+
   sig { abstract.returns(::Coil::AnyMessageClass) }
   def message_parent_class; end
 end


### PR DESCRIPTION
When periodically checking for unprocessed messages, there's a risk of encountering `ActiveRecord::SubclassNotFound`, e.g. if a legacy message class was removed without deleting the messages of that type.

Rather than allow that to break the periodic jobs, skip such message types.