### PR TITLE
Fix `message_class_for(type)`

### DIFF
--- a/app/jobs/coil/transactional_messages_cleanup_job.rb
+++ b/app/jobs/coil/transactional_messages_cleanup_job.rb
@@ -93,7 +93,11 @@ module Coil
     end
 
     def message_class_for(type)
-      message_parent_class.sti_class_for(type)
+      if ActiveRecord.version < Gem::Version.new("6.1.0")
+        message_parent_class.send(:find_sti_class, type)
+      else
+        message_parent_class.sti_class_for(type)
+      end
     rescue ActiveRecord::SubclassNotFound
     end
 

--- a/app/jobs/coil/transactional_messages_periodic_job.rb
+++ b/app/jobs/coil/transactional_messages_periodic_job.rb
@@ -29,7 +29,11 @@ module Coil
     private
 
     def message_class_for(type)
-      message_parent_class.sti_class_for(type)
+      if ActiveRecord.version < Gem::Version.new("6.1.0")
+        message_parent_class.send(:find_sti_class, type)
+      else
+        message_parent_class.sti_class_for(type)
+      end
     rescue ActiveRecord::SubclassNotFound
     end
 


### PR DESCRIPTION
Fix `message_class_for(type)` to work on older versions of ActiveRecord.
### Details
We've implemented `message_class_for(type)` using ActiveRecord's `sti_class_for` method, but that was first introduced in ActiveRecord 6.1.0, and we currently aim to support versions as old as 6.0.6, so we need to provide an alternative implementation.