### PR TITLE
fix(rbi): ensure `ActiveRecord::Transaction` is defined

### DIFF
--- a/rbi/coil.rbi
+++ b/rbi/coil.rbi
@@ -175,6 +175,11 @@ module Coil::PreventDestruction
   def prevent_destruction; end
 end
 
+# ActiveRecord::Transaction was first defined in version 7.2
+module ActiveRecord
+  class Transaction; end unless defined?(ActiveRecord::Transaction)
+end
+
 module Coil::QueueLocking
   include ::Kernel
   extend ::Coil::QueueLocking


### PR DESCRIPTION
Fix Coil's RBI file so that type-checking works regardless of which Rails version the host application is using.
### Context
In #32 we added support for Rails versions 7.2 and newer, in which an `ActiveRecord::Transaction` object gets passed to the provided block when calling `ActiveRecord::Base.transaction()`. The [type-signature](https://github.com/OdekoTeam/coil/pull/32/files#diff-81eacc3f9f146276476b7adfac32f73d601455e0d8ae730a1b45de1034c1d3a6) we provided with that change was intended to support both old and new Rails versions by using `T.any`:

    blk: T.any(
      # ActiveRecord versions 7.2 and newer yield a transaction as the block arg.
      T.proc.params(arg0: ActiveRecord::Transaction).returns(T.type_parameter(:P)),
      # Earlier versions yield to the block with no args.
      T.proc.returns(T.type_parameter(:P))
    )

But the `ActiveRecord::Transaction` class did not even exist prior to version 7.2, causing type-checking to fail if the host project uses an older Rails version.

Fix that by conditionally defining `ActiveRecord::Transaction` in the RBI file.