### PR TITLE
Fix: ActiveRecord::Migration[6.0]

### DIFF
--- a/db/migrate/20260309171521_index_inbox_messages_on_type.rb
+++ b/db/migrate/20260309171521_index_inbox_messages_on_type.rb
@@ -1,6 +1,6 @@
 # typed: false
 
-class IndexInboxMessagesOnType < ActiveRecord::Migration[8.1]
+class IndexInboxMessagesOnType < ActiveRecord::Migration[6.0]
   disable_ddl_transaction!
 
   # Indexing on `type` improves performance when a periodic job queries for all

--- a/db/migrate/20260309173914_index_outbox_messages_on_type.rb
+++ b/db/migrate/20260309173914_index_outbox_messages_on_type.rb
@@ -1,6 +1,6 @@
 # typed: false
 
-class IndexOutboxMessagesOnType < ActiveRecord::Migration[8.1]
+class IndexOutboxMessagesOnType < ActiveRecord::Migration[6.0]
   disable_ddl_transaction!
 
   # Indexing on `type` improves performance when a periodic job queries for all


### PR DESCRIPTION
Fix the version in some recently-added (#44) migrations.

Our lowest supported version of Rails is 6.0.6, so migrations must use a version that Rails 6.0 can recognize.