### PR TITLE
Improve Retry Policy

### DIFF
--- a/app/jobs/coil/transactional_messages_job.rb
+++ b/app/jobs/coil/transactional_messages_job.rb
@@ -10,8 +10,6 @@ module Coil
     # job to pick up where we left off.
     MAX_DURATION = 5.minutes
 
-    sidekiq_options retry: 4, dead: false
-
     def perform(key, processor_name = self.class.to_s)
       deadline = Time.current + MAX_DURATION
       next_in_line = process_messages(key:, processor_name:, deadline:)
@@ -38,18 +36,40 @@ module Coil
         next_in_line = next_message(key:, processor_name:)
         return next_in_line if next_in_line.nil? || Time.current > deadline
 
-        locking(key) do
-          message = next_message(key:, processor_name:)
+        outcome = process_next(key:, processor_name:)
+        raise outcome.error if outcome.error
+      end
+    end
 
-          if message.present?
-            around_process(message, processor_name:) do
-              pre_process(message)
-              message.processed(processor_name:)
-              process(message)
+    class Outcome
+      attr_accessor :error
+    end
+
+    def process_next(key:, processor_name:)
+      outcome = Outcome.new
+
+      locking(key) do
+        message = next_message(key:, processor_name:)
+
+        if message.present?
+          message.increment!(:processor_attempts)
+          begin
+            # Use a nested transaction and deferred error-handling to ensure the
+            # processor_attempts increment persists, even if the attempt fails.
+            ApplicationRecord.transaction(requires_new: true) do
+              around_process(message, processor_name:) do
+                pre_process(message)
+                message.processed(processor_name:)
+                process(message)
+              end
             end
+          rescue => e
+            outcome.error = e
           end
         end
       end
+
+      outcome
     end
 
     def around_process(message, processor_name:, &blk)

--- a/app/jobs/coil/transactional_messages_periodic_job.rb
+++ b/app/jobs/coil/transactional_messages_periodic_job.rb
@@ -1,17 +1,28 @@
 # typed: strict
 
+require "sidekiq/api"
+
 # The periodic job acts as a fallback mechanism, polling for messages that were
 # not enqueued and processed automatically upon create, e.g. due to a failure to
 # push a job onto the Redis queue.
 module Coil
   class TransactionalMessagesPeriodicJob < ApplicationJob
+    ATTEMPTS_THRESHOLD = 3
+
     def perform
-      t = Time.current - TransactionalMessagesJob::MAX_DURATION
+      q = Sidekiq::Queue.new(Coil.sidekiq_queue)
+      t = Time.current - q.latency - TransactionalMessagesJob::MAX_DURATION
 
       # Identify distinct message types, their associated job types, and
-      # the distinct keys for which we have unprocessed messages (excluding
-      # very recent messages, since a TransactionalMessagesJob may still be
-      # processing those). Then, enqueue the necessary jobs for those keys.
+      # the distinct keys for which we have unprocessed messages.
+      #
+      # Exclude very recent messages, since a TransactionalMessagesJob could
+      # still be processing those.
+      #
+      # Exclude keys where a processor has already initiated several attempts,
+      # since that's a strong indicator that automatic retries are in play.
+      #
+      # Then, enqueue the appropriate jobs.
       message_parent_class.select(:type).distinct.pluck(:type).each do |type|
         message_class = message_class_for(type)
         next unless message_class.present?
@@ -20,7 +31,8 @@ module Coil
         message_class
           .unprocessed(processor_name: job_class.name)
           .where(created_at: nil...t)
-          .distinct
+          .group(:key)
+          .having("MAX(processor_attempts) < ?", ATTEMPTS_THRESHOLD)
           .pluck(:key)
           .each { |k| job_class.perform_async(k) }
       end

--- a/db/migrate/20260314134950_add_processor_attempts_to_inbox_messages.rb
+++ b/db/migrate/20260314134950_add_processor_attempts_to_inbox_messages.rb
@@ -1,0 +1,18 @@
+# typed: false
+
+class AddProcessorAttemptsToInboxMessages < ActiveRecord::Migration[6.0]
+  def change
+    comment = <<~DOC.squish
+      Number of processor attempts that have been initiated on this message.
+    DOC
+
+    add_column(
+      :coil_inbox_messages,
+      :processor_attempts,
+      :integer,
+      null: false,
+      default: 0,
+      comment:
+    )
+  end
+end

--- a/db/migrate/20260314162532_add_processor_attempts_to_outbox_messages.rb
+++ b/db/migrate/20260314162532_add_processor_attempts_to_outbox_messages.rb
@@ -1,0 +1,18 @@
+# typed: false
+
+class AddProcessorAttemptsToOutboxMessages < ActiveRecord::Migration[6.0]
+  def change
+    comment = <<~DOC.squish
+      Number of processor attempts that have been initiated on this message.
+    DOC
+
+    add_column(
+      :coil_outbox_messages,
+      :processor_attempts,
+      :integer,
+      null: false,
+      default: 0,
+      comment:
+    )
+  end
+end

--- a/sorbet/rbi/dsl/coil/inbox/message.rbi
+++ b/sorbet/rbi/dsl/coil/inbox/message.rbi
@@ -873,6 +873,51 @@ class Coil::Inbox::Message
     sig { void }
     def metadata_will_change!; end
 
+    sig { returns(::Integer) }
+    def processor_attempts; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def processor_attempts=(value); end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def processor_attempts_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_was; end
+
+    sig { void }
+    def processor_attempts_will_change!; end
+
     sig { void }
     def restore_created_at!; end
 
@@ -887,6 +932,9 @@ class Coil::Inbox::Message
 
     sig { void }
     def restore_metadata!; end
+
+    sig { void }
+    def restore_processor_attempts!; end
 
     sig { void }
     def restore_type!; end
@@ -926,6 +974,12 @@ class Coil::Inbox::Message
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_processor_attempts; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_type; end
@@ -1094,6 +1148,9 @@ class Coil::Inbox::Message
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_type?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/coil/outbox/message.rbi
+++ b/sorbet/rbi/dsl/coil/outbox/message.rbi
@@ -873,6 +873,51 @@ class Coil::Outbox::Message
     sig { void }
     def metadata_will_change!; end
 
+    sig { returns(::Integer) }
+    def processor_attempts; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def processor_attempts=(value); end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def processor_attempts_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_was; end
+
+    sig { void }
+    def processor_attempts_will_change!; end
+
     sig { void }
     def restore_created_at!; end
 
@@ -887,6 +932,9 @@ class Coil::Outbox::Message
 
     sig { void }
     def restore_metadata!; end
+
+    sig { void }
+    def restore_processor_attempts!; end
 
     sig { void }
     def restore_type!; end
@@ -926,6 +974,12 @@ class Coil::Outbox::Message
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_processor_attempts; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_type; end
@@ -1094,6 +1148,9 @@ class Coil::Outbox::Message
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_type?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/dummy/inbox/bar_message.rbi
+++ b/sorbet/rbi/dsl/dummy/inbox/bar_message.rbi
@@ -878,6 +878,51 @@ class Dummy::Inbox::BarMessage
     sig { void }
     def metadata_will_change!; end
 
+    sig { returns(::Integer) }
+    def processor_attempts; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def processor_attempts=(value); end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def processor_attempts_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_was; end
+
+    sig { void }
+    def processor_attempts_will_change!; end
+
     sig { void }
     def restore_created_at!; end
 
@@ -892,6 +937,9 @@ class Dummy::Inbox::BarMessage
 
     sig { void }
     def restore_metadata!; end
+
+    sig { void }
+    def restore_processor_attempts!; end
 
     sig { void }
     def restore_type!; end
@@ -931,6 +979,12 @@ class Dummy::Inbox::BarMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_processor_attempts; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_type; end
@@ -1099,6 +1153,9 @@ class Dummy::Inbox::BarMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_type?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/dummy/inbox/foo_message.rbi
+++ b/sorbet/rbi/dsl/dummy/inbox/foo_message.rbi
@@ -878,6 +878,51 @@ class Dummy::Inbox::FooMessage
     sig { void }
     def metadata_will_change!; end
 
+    sig { returns(::Integer) }
+    def processor_attempts; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def processor_attempts=(value); end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def processor_attempts_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_was; end
+
+    sig { void }
+    def processor_attempts_will_change!; end
+
     sig { void }
     def restore_created_at!; end
 
@@ -892,6 +937,9 @@ class Dummy::Inbox::FooMessage
 
     sig { void }
     def restore_metadata!; end
+
+    sig { void }
+    def restore_processor_attempts!; end
 
     sig { void }
     def restore_type!; end
@@ -931,6 +979,12 @@ class Dummy::Inbox::FooMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_processor_attempts; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_type; end
@@ -1099,6 +1153,9 @@ class Dummy::Inbox::FooMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_type?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/dummy/inbox/who_message.rbi
+++ b/sorbet/rbi/dsl/dummy/inbox/who_message.rbi
@@ -878,6 +878,51 @@ class Dummy::Inbox::WhoMessage
     sig { void }
     def metadata_will_change!; end
 
+    sig { returns(::Integer) }
+    def processor_attempts; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def processor_attempts=(value); end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def processor_attempts_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_was; end
+
+    sig { void }
+    def processor_attempts_will_change!; end
+
     sig { void }
     def restore_created_at!; end
 
@@ -892,6 +937,9 @@ class Dummy::Inbox::WhoMessage
 
     sig { void }
     def restore_metadata!; end
+
+    sig { void }
+    def restore_processor_attempts!; end
 
     sig { void }
     def restore_type!; end
@@ -931,6 +979,12 @@ class Dummy::Inbox::WhoMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_processor_attempts; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_type; end
@@ -1099,6 +1153,9 @@ class Dummy::Inbox::WhoMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_type?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/dummy/outbox/bar_message.rbi
+++ b/sorbet/rbi/dsl/dummy/outbox/bar_message.rbi
@@ -878,6 +878,51 @@ class Dummy::Outbox::BarMessage
     sig { void }
     def metadata_will_change!; end
 
+    sig { returns(::Integer) }
+    def processor_attempts; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def processor_attempts=(value); end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def processor_attempts_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_was; end
+
+    sig { void }
+    def processor_attempts_will_change!; end
+
     sig { void }
     def restore_created_at!; end
 
@@ -892,6 +937,9 @@ class Dummy::Outbox::BarMessage
 
     sig { void }
     def restore_metadata!; end
+
+    sig { void }
+    def restore_processor_attempts!; end
 
     sig { void }
     def restore_type!; end
@@ -931,6 +979,12 @@ class Dummy::Outbox::BarMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_processor_attempts; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_type; end
@@ -1099,6 +1153,9 @@ class Dummy::Outbox::BarMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_type?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/dummy/outbox/foo_message.rbi
+++ b/sorbet/rbi/dsl/dummy/outbox/foo_message.rbi
@@ -878,6 +878,51 @@ class Dummy::Outbox::FooMessage
     sig { void }
     def metadata_will_change!; end
 
+    sig { returns(::Integer) }
+    def processor_attempts; end
+
+    sig { params(value: ::Integer).returns(::Integer) }
+    def processor_attempts=(value); end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def processor_attempts_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def processor_attempts_came_from_user?; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_in_database; end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def processor_attempts_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def processor_attempts_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def processor_attempts_was; end
+
+    sig { void }
+    def processor_attempts_will_change!; end
+
     sig { void }
     def restore_created_at!; end
 
@@ -892,6 +937,9 @@ class Dummy::Outbox::FooMessage
 
     sig { void }
     def restore_metadata!; end
+
+    sig { void }
+    def restore_processor_attempts!; end
 
     sig { void }
     def restore_type!; end
@@ -931,6 +979,12 @@ class Dummy::Outbox::FooMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([::Integer, ::Integer])) }
+    def saved_change_to_processor_attempts; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_type; end
@@ -1099,6 +1153,9 @@ class Dummy::Outbox::FooMessage
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_metadata?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_processor_attempts?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_type?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/shims/sidekiq.rbi
+++ b/sorbet/shims/sidekiq.rbi
@@ -1,0 +1,9 @@
+# typed: true
+
+class Sidekiq::Queue
+  sig { params(name: String).void }
+  def initialize(name = "default"); end
+
+  sig { returns(Float) }
+  def latency; end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_173914) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_14_162532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_173914) do
     t.datetime "created_at", null: false
     t.jsonb "key", null: false
     t.jsonb "metadata", default: {}, null: false
+    t.integer "processor_attempts", default: 0, null: false, comment: "Number of processor attempts that have been initiated on this message."
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.jsonb "value", null: false
@@ -55,6 +56,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_173914) do
     t.datetime "created_at", null: false
     t.jsonb "key", null: false
     t.jsonb "metadata", default: {}, null: false
+    t.integer "processor_attempts", default: 0, null: false, comment: "Number of processor attempts that have been initiated on this message."
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.jsonb "value", null: false

--- a/spec/jobs/coil/transactional_messages_job_spec.rb
+++ b/spec/jobs/coil/transactional_messages_job_spec.rb
@@ -29,6 +29,22 @@ RSpec.shared_examples :transactional_messages_job do
       .to eq("EventReplay:2023-05-24")
   end
 
+  it "increments processor_attempts" do
+    expect { job.perform(key) }
+      .to change { message1.reload.processor_attempts }.by(1)
+      .and change { message2.reload.processor_attempts }.by(1)
+  end
+
+  it "increments processor_attempts even if a database transaction fails" do
+    allow(job).to receive(:around_process) do
+      ApplicationRecord.connection.execute("some invalid statement")
+    end
+
+    expect { expect { job.perform(key) }.to raise_error(ActiveRecord::StatementInvalid) }
+      .to change { message1.reload.processor_attempts }.by(1)
+      .and change { message2.reload.processor_attempts }.by(0)
+  end
+
   it "does not enqueue a subsequent job" do
     expect { job.perform(key) }
       .not_to change(job.class.jobs, :size)

--- a/spec/jobs/coil/transactional_messages_periodic_job_spec.rb
+++ b/spec/jobs/coil/transactional_messages_periodic_job_spec.rb
@@ -21,6 +21,15 @@ RSpec.shared_examples :transactional_messages_periodic_job do
     box::BarMessage.create!(key: "z", value: {}, metadata: {}, created_at:)
   end
 
+  let(:queue) { double(:queue, latency: 0) }
+
+  before(:each) do
+    allow(Sidekiq::Queue)
+      .to receive(:new)
+      .with(Coil.sidekiq_queue)
+      .and_return(queue)
+  end
+
   it "enqueues jobs to process unprocessed messages" do
     expect { periodic_job.perform }
       .to change(box::FooMessagesJob.jobs, :size).by(1)
@@ -44,12 +53,46 @@ RSpec.shared_examples :transactional_messages_periodic_job do
     expect(bar_jobs.map { _1["args"] }).to contain_exactly(["y"], ["z"])
   end
 
+  it "accounts for queue latency" do
+    allow(queue).to receive(:latency).and_return(600)
+
+    t = 600.seconds.ago - Coil::TransactionalMessagesJob::MAX_DURATION
+    [
+      [foo_message_w, t - 1.second],
+      [bar_message_x, t + 1.second],
+      [bar_message_y, t - 1.second],
+      [bar_message_z_1, t - 1.second],
+      [bar_message_z_2, t - 1.second]
+    ].each do |msg, created_at|
+      msg.update!(created_at:)
+    end
+
+    expect { periodic_job.perform }
+      .to change(box::FooMessagesJob.jobs, :size).by(1)
+      .and change(box::BarMessagesJob.jobs, :size).by(2)
+
+    bar_jobs = box::BarMessagesJob.jobs.last(2)
+    expect(bar_jobs.map { _1["args"] }).to contain_exactly(["y"], ["z"])
+  end
+
   it "ignores messages that were already processed" do
     foo_message_w.processed(processor_name: box::FooMessagesJob.name)
 
     expect { periodic_job.perform }
       .to change(box::FooMessagesJob.jobs, :size).by(0)
       .and change(box::BarMessagesJob.jobs, :size).by(3)
+  end
+
+  it "ignores messages that were already attempted several times" do
+    n = Coil::TransactionalMessagesPeriodicJob::ATTEMPTS_THRESHOLD
+    bar_message_z_1.update!(processor_attempts: n)
+
+    expect { periodic_job.perform }
+      .to change(box::FooMessagesJob.jobs, :size).by(1)
+      .and change(box::BarMessagesJob.jobs, :size).by(2)
+
+    bar_jobs = box::BarMessagesJob.jobs.last(2)
+    expect(bar_jobs.map { _1["args"] }).to contain_exactly(["x"], ["y"])
   end
 
   it "ignores messages whose class cannot be found" do


### PR DESCRIPTION
Use a smarter retry policy to keep system resource usage at a reasonable level.

### Motivation

The periodic job (`TransactionalMessagesPeriodicJob`) was designed as a fallback mechanism to ensure message processing attempts eventually occur, even in the following scenarios:
- A job fails to make it onto the Redis queue when a message is created.
- A fix gets deployed for a bug that was causing processing failures.

The approach was relatively simple: each message-processing job was allowed just 4 retries, but every periodic job would enqueue another message-processing job, triggering another batch of attempts.

But if a large collection of failing messages accumulates, it can lead to an unreasonable number/frequency of processing attempts, putting strain on the database and other system resources.

### Solution

Use Sidekiq's default retry policy (exponential backoff with up to 25 retries over roughly 20 days) for the message-processing jobs, and constrain the periodic job to avoid queueing additional jobs for messages that have already entered a retry cycle.

If a message exhausts all 25 retries, Sidekiq moves it to the Dead set, where it remains for the next 6 months, making it easy to manually trigger further attempts (e.g. after deploying a bug fix). Note that if a subsequent message of the same type and key is created, that will naturally trigger further processing attempts, making manual intervention unnecessary.

### Example: a message that can't be processed due to a bug

A `FooMessage` is created with key `"abc"`. Processing fails because of a bug in `FooMessagesJob` (the `FooMessage` processor).

**Old behavior:**

1. The job fails and retries 4 times (quickly, over a few minutes).
2. After the 4th retry, the job is dropped.
3. The periodic job runs, sees an unprocessed message for key `"abc"`, and enqueues a new job.
4. That job fails 4 more times and is dropped again.
5. Steps 3-4 repeat indefinitely — every time the periodic job runs, it fires off another round of doomed attempts.

**New behavior:**

1. The job fails and retries with exponential backoff — up to 25 retries spread over ~20 days.
2. The periodic job runs, sees that the message already has several `processor_attempts`, and skips it.
3. If all 25 retries are exhausted, the job lands in Sidekiq's Dead set. No further automatic attempts occur.

Now suppose the bug is fixed and deployed, and before anyone has a chance to manually retry the dead job, a second `FooMessage` arrives with key `"abc"`.
* The message creation enqueues a fresh `FooMessagesJob` for that key.
* Since the job processes messages for a given type+key in order, it picks up the original failed message first, processes it successfully under the fixed code, then processes the new one.