### PR TITLE
fix(trivy): pin amd64 architecture to fix exec format error

### DIFF
--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -48,7 +48,9 @@ resources:
   icon: docker
   source:
     repository: aquasec/trivy
-    tag: "latest"
+    tag: "latest-amd64"
+    registry_mirror:
+      host: docker-mirror.odeko.com
 - name: slack-alert
   type: slack-notification
   source:

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -38,7 +38,7 @@ resources:
   type: registry-image
   source:
     repository: aquasec/trivy
-    tag: "latest"
+    tag: "latest-amd64"
     registry_mirror:
       host: docker-mirror.odeko.com
 - name: slack-alert


### PR DESCRIPTION
## Summary
- The `aquasec/trivy` multi-arch Docker manifest resolves to a non-amd64 image on Concourse workers, causing `exec format error`
- Pins `trivy-image` resource to `latest-amd64` in all pipeline configs