### PR TITLE
fix(security): pin trivy image to 0.69.3-amd64 per GHSA-cxm3-wv7p-598c

### DIFF
--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -48,7 +48,7 @@ resources:
   icon: docker
   source:
     repository: aquasec/trivy
-    tag: "latest-amd64"
+    tag: "0.69.3-amd64"
     registry_mirror:
       host: docker-mirror.odeko.com
 - name: slack-alert

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -38,7 +38,7 @@ resources:
   type: registry-image
   source:
     repository: aquasec/trivy
-    tag: "latest-amd64"
+    tag: "0.69.3-amd64"
     registry_mirror:
       host: docker-mirror.odeko.com
 - name: slack-alert


### PR DESCRIPTION
## Summary
- Pins `aquasec/trivy` from `latest-amd64` to `0.69.3-amd64` in all pipeline files
- Version 0.69.3 is the last known safe release before the March 19, 2026 supply chain attack

## References
- [Aqua Security Advisory](https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/)
- [Docker Hub Advisory](https://www.docker.com/blog/trivy-supply-chain-compromise-what-docker-hub-users-should-know/)
- [GHSA-cxm3-wv7p-598c](https://github.com/advisories/GHSA-cxm3-wv7p-598c)
- [Odeko Investigation Notebook](https://app.datadoghq.com/notebook/14124315)
